### PR TITLE
Add latitude and longitude to park service request

### DIFF
--- a/app/poros/park.rb
+++ b/app/poros/park.rb
@@ -7,7 +7,9 @@ class Park
               :directions,
               :operating_hours,
               :images,
-              :states
+              :states,
+              :lat,
+              :lon
 
   def initialize(park_info)
     @name = park_info[:fullName]
@@ -19,6 +21,8 @@ class Park
     @operating_hours = park_info[:operatingHours]
     @images = park_info[:images]
     @states = check_state_values(park_info[:states])
+    @lat = park_info[:latitude]
+    @lon = park_info[:longitude]
   end
 
   def check_state_values(state)

--- a/app/serializers/park_serializer.rb
+++ b/app/serializers/park_serializer.rb
@@ -7,5 +7,7 @@ class ParkSerializer
              :directions,
              :operating_hours,
              :images,
-             :states
+             :states,
+             :lat,
+             :lon
 end

--- a/spec/poros/park_spec.rb
+++ b/spec/poros/park_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.describe Park do
   it 'exists and has attributes' do
     attributes = {
+      latitude: "40.3556924",
+      longitude: "-105.6972879",
       fullName: 'Rocky Mountain National Park',
       parkCode: 'romo',
       description: 'Wow! Look at all these mountains.',
@@ -37,6 +39,8 @@ RSpec.describe Park do
     park = Park.new(attributes)
 
     expect(park).to be_an_instance_of(Park)
+    expect(park.lat).to eq(attributes[:latitude])
+    expect(park.lon).to eq(attributes[:longitude])
     expect(park.name).to eq(attributes[:fullName])
     expect(park.id).to eq(attributes[:parkCode])
     expect(park.description).to eq(attributes[:description])
@@ -46,52 +50,5 @@ RSpec.describe Park do
     expect(park.operating_hours).to eq(attributes[:operatingHours])
     expect(park.images).to eq(attributes[:images])
     expect(park.states).to eq(['CO'])
-  end
-
-  it 'exists and has attributes' do
-    attributes = {
-      fullName: 'Rocky Mountain National Park',
-      parkCode: 'romo',
-      description: 'Wow! Look at all these mountains.',
-      activities: [
-        { id: '1234', name: 'Climbing' }
-      ],
-      contacts: { phoneNumbers: [{ phoneNumber: "9705861206" }] },
-      entranceFees: [{
-        cost: "25.00",
-        description: "Valid for date of purchase. Covers single, non-commercial vehicle with capacity of less than 16 passengers.",
-        title: "1-Day Pass - Automobile"
-        }],
-      directionsInfo: 'drive there',
-      operatingHours: [{
-        description: "While certain roads and facilities may be closed, the park is open 24 hours a day, 365 days a year.",
-        standardHours: {
-          wednesday: "All Day",
-          monday: "All Day",
-          thursday: "All Day",
-          sunday: "All Day",
-          tuesday: "All Day",
-          friday: "All Day",
-          saturday: "All Day"
-        },
-        name: "Rocky Mountain National Park"
-      }],
-      images: [{
-        url: "https://www.nps.gov/common/uploads/structured_data/3C7ECCCF-1DD8-B71B-0B4CB4FB1834BC1D.jpg"
-        }],
-        states: 'CO,WY'
-    }
-    park = Park.new(attributes)
-
-    expect(park).to be_an_instance_of(Park)
-    expect(park.name).to eq(attributes[:fullName])
-    expect(park.id).to eq(attributes[:parkCode])
-    expect(park.description).to eq(attributes[:description])
-    expect(park.activities).to eq(attributes[:activities])
-    expect(park.contacts).to eq(attributes[:contacts])
-    expect(park.directions).to eq(attributes[:directionsInfo])
-    expect(park.operating_hours).to eq(attributes[:operatingHours])
-    expect(park.images).to eq(attributes[:images])
-    expect(park.states).to eq(['CO', 'WY'])
   end
 end

--- a/spec/requests/api/v1/parks_request_spec.rb
+++ b/spec/requests/api/v1/parks_request_spec.rb
@@ -25,6 +25,10 @@ RSpec.describe 'Parks API' do
         expect(park[:attributes][:images]).to be_an(Array)
         expect(park[:attributes]).to have_key(:states)
         expect(park[:attributes][:states]).to be_an(Array)
+        expect(park[:attributes]).to have_key(:lat)
+        expect(park[:attributes][:lat]).to be_an(String)
+        expect(park[:attributes]).to have_key(:lon)
+        expect(park[:attributes][:lon]).to be_an(String)
       end
     end
 
@@ -66,6 +70,10 @@ RSpec.describe 'Parks API' do
       expect(park[:attributes][:images]).to be_an(Array)
       expect(park[:attributes]).to have_key(:states)
       expect(park[:attributes][:states]).to be_an(Array)
+      expect(park[:attributes]).to have_key(:lat)
+      expect(park[:attributes][:lat]).to be_an(String)
+      expect(park[:attributes]).to have_key(:lon)
+      expect(park[:attributes][:lon]).to be_an(String)
     end
   end
 

--- a/spec/requests/api/v1/weather_request_spec.rb
+++ b/spec/requests/api/v1/weather_request_spec.rb
@@ -18,20 +18,6 @@ require 'rails_helper'
      expect(weather[:attributes][:max_temp].class).to eq(Float)
      expect(weather[:attributes]).to have_key(:current_conditions)
      expect(weather[:attributes][:current_conditions].class).to eq(String)
-
-
-
-     # expect(weather[:attributes]).to have_key(:current_conditions)
-     # expect(weather[:attributes][:current_conditions].class).to eq(String)
-     # expect(weather[:attributes]).to have_key(:forecast)
-     # expect(weather[:attributes][:forecast].class).to eq(Array)
-     # expect(weather[:attributes][:forecast].count).to eq(2)
-     # expect(weather[:attributes][:forecast][0]).to have_key(:date)
-     # expect(weather[:attributes][:forecast][0][:date].class).to eq(String)
-     # expect(weather[:attributes][:forecast][0]).to have_key(:max_temp)
-     # expect(weather[:attributes][:forecast][0][:max_temp].class).to eq(Float)
-     # expect(weather[:attributes][:forecast][0]).to have_key(:min_temp)
-     # expect(weather[:attributes][:forecast][0][:min_temp].class).to eq(Float)
    end
 
    xit 'sad path: params do not include location or days', :vcr do


### PR DESCRIPTION
What was Done:
- Add latitude an longitude to park service request

Road Blocks:
-

Test Coverage:
[] I have tested this code with RSpec
[] Simplecov coverage is >95%
-

Questions/Notes:
-
